### PR TITLE
adds the mode name to the scale box

### DIFF
--- a/apps/fretonator-web/src/app/common/fretonator/scale-map/scale-map.component.html
+++ b/apps/fretonator-web/src/app/common/fretonator/scale-map/scale-map.component.html
@@ -1,7 +1,7 @@
 <div class="scaleMap__row">
   <div class="scaleDisplay">
     <h3 class="scaleDisplay__title"
-        [class.infoHighlight]="isTheoretical"><span *ngIf="isTheoretical">Theoretical &nbsp;</span>{{ modeDisplayString }} Scale</h3>
+        [class.infoHighlight]="isTheoretical">{{ modeDisplayString }} <span *ngIf="isTheoretical">&nbsp;(Theoretical Scale)</span></h3>
     <div class="scaleDisplay__notes">
       <ng-container *ngFor="let note of modeMap; let i = index">
         <p class="scaleDisplay__note">

--- a/apps/fretonator-web/src/app/common/fretonator/scale-map/scale-map.component.html
+++ b/apps/fretonator-web/src/app/common/fretonator/scale-map/scale-map.component.html
@@ -1,7 +1,7 @@
 <div class="scaleMap__row">
   <div class="scaleDisplay">
     <h3 class="scaleDisplay__title"
-        [class.infoHighlight]="isTheoretical"><span *ngIf="isTheoretical">Theoretical &nbsp;</span>Scale</h3>
+        [class.infoHighlight]="isTheoretical"><span *ngIf="isTheoretical">Theoretical &nbsp;</span>{{ modeDisplayString }} Scale</h3>
     <div class="scaleDisplay__notes">
       <ng-container *ngFor="let note of modeMap; let i = index">
         <p class="scaleDisplay__note">

--- a/apps/fretonator-web/src/app/pages/home/home-index/__snapshots__/home-index.component.spec.ts.snap
+++ b/apps/fretonator-web/src/app/pages/home/home-index/__snapshots__/home-index.component.spec.ts.snap
@@ -1412,7 +1412,7 @@ exports[`HomeIndexComponent should create 1`] = `
                   class="scaleDisplay__title"
                 >
                   
-                  Scale
+                  C Ionian (Major) Scale
                 </h3>
                 <div
                   class="scaleDisplay__notes"

--- a/apps/fretonator-web/src/app/pages/home/home-index/__snapshots__/home-index.component.spec.ts.snap
+++ b/apps/fretonator-web/src/app/pages/home/home-index/__snapshots__/home-index.component.spec.ts.snap
@@ -1411,8 +1411,8 @@ exports[`HomeIndexComponent should create 1`] = `
                 <h3
                   class="scaleDisplay__title"
                 >
+                  C Ionian (Major) 
                   
-                  C Ionian (Major) Scale
                 </h3>
                 <div
                   class="scaleDisplay__notes"


### PR DESCRIPTION
As requested in issue #78 , this adds the mode name to the scale box

![Fretonator_-_the_ultimate_interactive_free_guitar_theory_tool___C_Ionian__Major_](https://user-images.githubusercontent.com/7063963/98444653-c8f7ba80-210a-11eb-9cba-75771798f005.jpg)
